### PR TITLE
Fix pathNavigator and a few mark-down issues

### DIFF
--- a/plugins/pathNavigator.py
+++ b/plugins/pathNavigator.py
@@ -12,9 +12,12 @@ class pathNavigator(object):
 		if sequence == "..":
 			currentPath = pyTerm.getPath().split("/")[::-1]
 			currentPath = currentPath[1::]
-			currentPath = currentPath[::-1]
-			currentPath = "/".join(currentPath)
-			pyTerm.setPath(currentPath)
+			if currentPath[0] == '':
+				pyTerm.setPath('/')
+			else:
+				currentPath = currentPath[::-1]
+				currentPath = "/".join(currentPath)
+				pyTerm.setPath(currentPath)
 
 		elif sequence == "":
 			pyTerm.setPath("/home/"+pyTerm.getUser())

--- a/plugins/pathNavigator.py
+++ b/plugins/pathNavigator.py
@@ -22,7 +22,7 @@ class pathNavigator(object):
 				currentPath = "/".join(currentPath)
 				pyTerm.setPath(currentPath)
 
-		elif sequence == "":
+		elif sequence == "" or sequence == "~":
 			pyTerm.setPath("/home/"+pyTerm.getUser())
 
 		else:

--- a/plugins/pathNavigator.py
+++ b/plugins/pathNavigator.py
@@ -12,22 +12,24 @@ class pathNavigator(object):
 		except IndexError:
 			sequence = ""
 
-		if sequence == "..":
-			currentPath = pyTerm.getPath().split("/")[::-1]
-			currentPath = currentPath[1::]
+		if sequence == "..": # upward
+			currentPath = pyTerm.getPath().split("/")[::-1][1::]
 			if currentPath[0] == '':
 				pyTerm.setPath('/')
+				os.chdir(pyTerm.currentPath)
 			else:
-				currentPath = currentPath[::-1]
-				currentPath = "/".join(currentPath)
+				currentPath = "/".join(currentPath[::-1])
 				pyTerm.setPath(currentPath)
+				os.chdir(pyTerm.currentPath)
 
 		elif sequence == "" or sequence == "~":
 			pyTerm.setPath("/home/"+pyTerm.getUser())
+			os.chdir(pyTerm.currentPath)
 
-		else:
-			newPath = os.path.join(pyTerm.getPath(), sequence)
-			if os.path.isdir(newPath):
-				pyTerm.setPath(newPath)
+		else: # downward
+			currentPath = os.path.join(pyTerm.getPath(), sequence)
+			if os.path.isdir(currentPath):
+				pyTerm.setPath(currentPath)
+				os.chdir(pyTerm.currentPath)
 			else:
 				print 'Invalid Directory!'

--- a/plugins/pathNavigator.py
+++ b/plugins/pathNavigator.py
@@ -1,3 +1,5 @@
+import os
+
 class pathNavigator(object):
 
 	def __pytermconfig__(self):
@@ -9,6 +11,7 @@ class pathNavigator(object):
 			sequence = kwargs["sequence"][0]
 		except IndexError:
 			sequence = ""
+
 		if sequence == "..":
 			currentPath = pyTerm.getPath().split("/")[::-1]
 			currentPath = currentPath[1::]
@@ -21,3 +24,10 @@ class pathNavigator(object):
 
 		elif sequence == "":
 			pyTerm.setPath("/home/"+pyTerm.getUser())
+
+		else:
+			newPath = os.path.join(pyTerm.getPath(), sequence)
+			if os.path.isdir(newPath):
+				pyTerm.setPath(newPath)
+			else:
+				print 'Invalid Directory!'

--- a/plugins/pathNavigator.py
+++ b/plugins/pathNavigator.py
@@ -16,20 +16,18 @@ class pathNavigator(object):
 			currentPath = pyTerm.getPath().split("/")[::-1][1::]
 			if currentPath[0] == '':
 				pyTerm.setPath('/')
-				os.chdir(pyTerm.currentPath)
+
 			else:
-				currentPath = "/".join(currentPath[::-1])
-				pyTerm.setPath(currentPath)
-				os.chdir(pyTerm.currentPath)
+				pyTerm.setPath("/".join(currentPath[::-1]))
 
 		elif sequence == "" or sequence == "~":
 			pyTerm.setPath("/home/"+pyTerm.getUser())
-			os.chdir(pyTerm.currentPath)
 
 		else: # downward
 			currentPath = os.path.join(pyTerm.getPath(), sequence)
 			if os.path.isdir(currentPath):
 				pyTerm.setPath(currentPath)
-				os.chdir(pyTerm.currentPath)
 			else:
 				print 'Invalid Directory!'
+
+		os.chdir(pyTerm.currentPath)

--- a/readme.md
+++ b/readme.md
@@ -2,24 +2,24 @@
 
 ## What's PyTerm ##
 
-PyTerm is a terminal client for linux, that show highlights on the availables commands of your computer
+PyTerm is a Python-based terminal client for Linux that highlights the available commands of your computer.
 
 #Installation
 
-To install, you just need run this on terminal.
+To install, all you need to do is, run the following commands in your terminal:
 
 ```Shell
 $ git clone https://github.com/jeffersonmourak/pyTerm.git
 $ cd pyTerm/
 ```
 
-and done, just go to the Usage topic to see how to use this :)
+and that's it, now, just go to the Usage topic to see how to use this. :)
 
 #Usage
 
-So, how this project is just beginning, you just can run the terminal commands and those aliases.
+So, this project is just beginning, you can run the basic terminal commands and those aliases.
 
-To run the commands, you just need to run this command.
+To use PyTerm, you need to run the following in your terminal.
 
 ```Shell
 $ python terminal.py
@@ -27,24 +27,22 @@ $ python terminal.py
 
 #plugins
 
-A plugin is a python file inside of "plugin/" directory, this file must have a class with the name of file,
+A plugin is a Python file, placed inside `plugin/` directory, this file must have a class with the name of the file,
 
-example: if the file is plugin.py must have a class 
+Example: If the file is `plugin.py`, it must have a class `plugin` defined as follows:
 
 ```Python
-class plugin(Object:)
+class plugin(object):
 ```
 
-inside this class must have a method called 
+and this class must have a method called ` __pytermconfig__`.
 
-` __pytermconfig__`
+Without arguments, this method must return a dictionary, with those indexes, 
 
-without arguments, this method must return a dictionary, with those indexes, 
+* "command": Command is the command that will be run in the terminal
+* "callback": this is a function file, that will be called when the command is executed
 
-* "command": Command is the command that will be called on terminal
-* "callback": this is a function file, that will be called when the command is called
-
-The callback function must have ` *args, **kwargs ` as argument too, to enable get the configurations of terminal
+The callback function must have ` *args, **kwargs ` as argument too, to enable get the configurations of the terminal.
 
 ### Credits
 

--- a/readme.md
+++ b/readme.md
@@ -13,11 +13,11 @@ $ git clone https://github.com/jeffersonmourak/pyTerm.git
 $ cd pyTerm/
 ```
 
-and that's it, now, just go to the Usage topic to see how to use this. :)
+and you are all set. Now, just go to the Usage topic to see how to use this. :)
 
 #Usage
 
-So, this project is just beginning, you can run the basic terminal commands and those aliases.
+This project is just beginning, so you can run the very basic terminal commands and those aliases.
 
 To use PyTerm, you need to run the following in your terminal.
 
@@ -27,7 +27,7 @@ $ python terminal.py
 
 #plugins
 
-A plugin is a Python file, placed inside `plugin/` directory, this file must have a class with the name of the file,
+A plugin is a Python file, placed inside `plugin/` directory, this file must have a class with the name of the file.
 
 Example: If the file is `plugin.py`, it must have a class `plugin` defined as follows:
 
@@ -39,10 +39,10 @@ and this class must have a method called ` __pytermconfig__`.
 
 Without arguments, this method must return a dictionary, with those indexes, 
 
-* "command": Command is the command that will be run in the terminal
-* "callback": this is a function file, that will be called when the command is executed
+* `"command"`: is the command that will be run in the terminal
+* `"callback"`: is a function file, that will be called when the command is executed
 
-The callback function must have ` *args, **kwargs ` as argument too, to enable get the configurations of the terminal.
+The callback function must have ` *args` and `**kwargs ` as arguments too, these will allow getting the configurations of the terminal.
 
 ### Credits
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 setup(
       name='pyterm',
       version='0.1',
-      description='PyTerm is a terminal client for linux, that show a hightlight on the availables commands of your computer',
+      description='PyTerm is a Python-based terminal client for Linux, that highlights the available commands of your computer',
       url='https://github.com/jeffersonmourak/pyTerm',
       author='Jefferson Moura',
       author_email='jefinho.moura14@gmail.com',


### PR DESCRIPTION
**1. Without using `os` module's `chdir`, it does set the path in the prompt but does not actually change the directory.  So, if `pwd` is executed after `cd ..`, it prints out the child directory instead of the current directory.** 
**2. `cd ~` also leads to `/home/$USER/`now.**
**3. Navigate into the sub-directories of the current directory:**
It uses `os.path` module to check if the new path (as generated after appending the `sequence` to the previous path) leads to a valid directory. If it does lead to a valid sub-directory, the path is set, else, an error message `Invalid Directory!` is printed.

**4. Stop going back to the previous directory before we end up in a no-man's land:**
If I keep on going back to the previous directory by running `cd ..` again and again, I end up in a directory where `currentPath` is equal to `['']`, running `ls` here produces following error:

`Traceback (most recent call last):
  File "terminal.py", line 33, in <module>
    runCommand(shell.listener())
  File "terminal.py", line 29, in runCommand
    runCommand(shell.listener())
  File "terminal.py", line 29, in runCommand
    runCommand(shell.listener())
  File "terminal.py", line 29, in runCommand
    runCommand(shell.listener())
  File "terminal.py", line 29, in runCommand
    runCommand(shell.listener())
  File "terminal.py", line 28, in runCommand
    if commands.run(commandString,configs):
  File ".../pyTerm/CommandsList.py", line 101, in run
    self.callPlugin(commandString,config)
  File ".../pyTerm/CommandsList.py", line 20, in callPlugin
    command(pyTerm=config,sequence=sequence)
  File ".../pyTerm/plugins/listDirectory.py", line 11, in ls
    dirs = os.listdir(currentPath)
OSError: [Errno 2] No such file or directory: ''`

One possible solution, might be, to set the path to `/` when `currentPath[0]` becomes equal to `''`. 

**5. Fix markdown and project description in `setup.py`.**
